### PR TITLE
Add `by` keyword to start the proofs

### DIFF
--- a/Math2001/03_Parity_and_Divisibility/04_Modular_Arithmetic_Calculations.lean
+++ b/Math2001/03_Parity_and_Divisibility/04_Modular_Arithmetic_Calculations.lean
@@ -47,10 +47,10 @@ example {x : ℤ} : x ^ 3 ≡ x [ZMOD 3] := by
 /-! # Exercises -/
 
 
-example {n : ℤ} (hn : n ≡ 1 [ZMOD 3]) : n ^ 3 + 7 * n ≡ 2 [ZMOD 3] :=
+example {n : ℤ} (hn : n ≡ 1 [ZMOD 3]) : n ^ 3 + 7 * n ≡ 2 [ZMOD 3] := by
   sorry
 
-example (a b : ℤ) : (a + b) ^ 3 ≡ a ^ 3 + b ^ 3 [ZMOD 3] :=
+example (a b : ℤ) : (a + b) ^ 3 ≡ a ^ 3 + b ^ 3 [ZMOD 3] := by
   sorry
 
 example : ∃ a : ℤ, 4 * a ≡ 1 [ZMOD 7] := by


### PR DESCRIPTION
Add the `by` keyword to two proofs where it seemed to be missing. Without these the student might be confused by errors messages in their editor that don't make it obvious that this action is needed.