### PR TITLE
Don't override theme settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "workbench.colorTheme": "Default Light+",
     "editor.semanticHighlighting.enabled": true,
     "editor.semanticTokenColorCustomizations": {
             "[Default Light+]": {"rules": {"variable": "#7f197f"}}


### PR DESCRIPTION
It's jarring to open this repository and have my theme change. Removing this line keeps the theme to what the user has already set.