### PR TITLE
Fix link to Book of Proof

### DIFF
--- a/html/02_Proofs_with_Structure.html
+++ b/html/02_Proofs_with_Structure.html
@@ -1710,7 +1710,7 @@ real numbers <span class="math notranslate nohighlight">\(x\)</span>, <span clas
 <dl class="footnote brackets">
 <dt class="label" id="id39"><span class="brackets"><a class="fn-backref" href="#id37">3</a></span></dt>
 <dd><p>Example adapted from Hammack,
-<a class="reference external" href="https://www.people.vcu.edu/~rhammack/BookOfProof/">Book of Proof</a>, Section 7.3.</p>
+<a class="reference external" href="https://archive.org/details/book-of-proof-3rd-edition-2018-richard-hammack">Book of Proof</a>, Section 7.3.</p>
 </dd>
 </dl>
 </section>

--- a/html/03_Parity_and_Divisibility.html
+++ b/html/03_Parity_and_Divisibility.html
@@ -502,7 +502,7 @@ odd.</p>
 <dl class="footnote brackets">
 <dt class="label" id="id11"><span class="brackets"><a class="fn-backref" href="#id10">1</a></span></dt>
 <dd><p>Exercise taken from Hammack,
-<a class="reference external" href="https://www.people.vcu.edu/~rhammack/BookOfProof/">Book of Proof</a>, Chapter 9.</p>
+<a class="reference external" href="https://archive.org/details/book-of-proof-3rd-edition-2018-richard-hammack">Book of Proof</a>, Chapter 9.</p>
 </dd>
 </dl>
 </section>

--- a/html/06_Induction.html
+++ b/html/06_Induction.html
@@ -1382,7 +1382,7 @@ numbers <span class="math notranslate nohighlight">\(n\)</span>, <span class="ma
 <dl class="footnote brackets">
 <dt class="label" id="id22"><span class="brackets"><a class="fn-backref" href="#id19">1</a></span></dt>
 <dd><p>Example adapted from Hammack,
-<a class="reference external" href="https://www.people.vcu.edu/~rhammack/BookOfProof/">Book of Proof</a>, Section 10.5.</p>
+<a class="reference external" href="https://archive.org/details/book-of-proof-3rd-edition-2018-richard-hammack">Book of Proof</a>, Section 10.5.</p>
 </dd>
 </dl>
 </section>


### PR DESCRIPTION
The original link to Book of Proof (https://www.people.vcu.edu/~rhammack/BookOfProof/) no longer works. Several alternative mirrors or sources exist:
* https://archive.org/details/book-of-proof-3rd-edition-2018-richard-hammack
* https://richardhammack.github.io/BookOfProof/
* https://jdhsmith.math.iastate.edu/class/BookOfProof.pdf

Of these, the Internet Archive link is most likely to remain stable over time, so I propose switching to that.